### PR TITLE
watchOS Build Workflow

### DIFF
--- a/.github/workflows/xcodebuild.yml
+++ b/.github/workflows/xcodebuild.yml
@@ -40,3 +40,6 @@ jobs:
     - name: Build tvOS
       if: ${{ contains(github.event.pull_request.labels.*.name, 'tvOS') }}
       run:  xcodebuild -scheme OAuthSample -configuration Debug CODE_SIGNING_ALLOWED=NO -destination "generic/platform=tvOS"
+    - name: Build watchOS
+      if: ${{ contains(github.event.pull_request.labels.*.name, 'watchOS') }}
+      run:  xcodebuild -scheme OAuthSample -configuration Debug CODE_SIGNING_ALLOWED=NO -destination "generic/platform=watchOS"


### PR DESCRIPTION
- The GitHub build workflow will now build for watchOS if tagged with `watchOS` label.